### PR TITLE
Refactor rota endpoints to merge week objects

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -2,6 +2,7 @@ const express = require('express');
 const cors = require('cors');
 const fs = require('fs');
 const path = require('path');
+const rotaRouter = require('./routes/rota');
 const app = express();
 
 const PORT = 4000;
@@ -43,9 +44,6 @@ app.get('/api/shifts', (_, res) => {
   readFile('shifts.json').then(data => res.json(data));
 });
 
-app.get('/api/rota', (_, res) => {
-  readFile('rota.json').then(data => res.json(data));
-});
 
 app.get('/api/settings', (_, res) => {
   readFile('settings.json').then(data => res.json(data));
@@ -55,27 +53,8 @@ app.get('/api/subdepartments', (_, res) => {
   readFile('subdepartments.json').then(data => res.json(data));
 });
 
-// PUT to update rota.json
-app.put('/api/rota', (req, res) => {
-  const rota = req.body;
-  writeFile('rota.json', JSON.stringify(rota, null, 2))
-    .then(() => res.json({ success: true }))
-    .catch(err => {
-      console.error('❌ Failed to write rota file:', err);
-      res.status(500).json({ error: 'Failed to write rota file' });
-    });
-});
-
-// Also allow POST to update rota.json
-app.post('/api/rota', (req, res) => {
-  const rota = req.body;
-  writeFile('rota.json', JSON.stringify(rota, null, 2))
-    .then(() => res.json({ success: true }))
-    .catch(err => {
-      console.error('❌ Failed to write rota file:', err);
-      res.status(500).json({ error: 'Failed to write rota file' });
-    });
-});
+// Rota routes
+app.use('/api/rota', rotaRouter);
 
 // =================================================== //
 


### PR DESCRIPTION
## Summary
- load/save rota data as an object instead of an array
- merge posted week blocks with existing rota data
- add PUT and GET handlers for rota routes
- mount rota router in `server.js` and remove old `/api/rota` handlers

## Testing
- `CI=true npm test --silent -- --passWithNoTests`
- `curl -s -X POST http://localhost:4000/api/rota -H 'Content-Type: application/json' -d @/tmp/rota_post.json`
- `curl -s -X PUT http://localhost:4000/api/rota -H 'Content-Type: application/json' -d @/tmp/rota_put.json`

------
https://chatgpt.com/codex/tasks/task_e_684ad587b2648327ab9ad2b8ffcccea1